### PR TITLE
fix: DB에서 결과값을 반환받을 결과값의 경도/위도 순서 오류 수정

### DIFF
--- a/backend/src/main/java/com/zeun/ddamap/route/controller/NearbyStationController.java
+++ b/backend/src/main/java/com/zeun/ddamap/route/controller/NearbyStationController.java
@@ -18,6 +18,6 @@ public class NearbyStationController {
     @GetMapping("/nearby")
     public List<NearbyStationDTO> findNearbyStations(@RequestParam BigDecimal lng, @RequestParam BigDecimal lat) {
 
-        return nearbyStationService.findNearbyStationsWithDistance(lng, lat);
+        return nearbyStationService.findNearbyStationsWithDistance(lat, lng);
     }
 }

--- a/backend/src/main/java/com/zeun/ddamap/route/service/NearbyStationService.java
+++ b/backend/src/main/java/com/zeun/ddamap/route/service/NearbyStationService.java
@@ -18,7 +18,7 @@ public class NearbyStationService {
 
     public List<NearbyStationDTO> findNearbyStationsWithDistance(BigDecimal lng, BigDecimal lat) {
 
-        String userPoint = String.format("POINT(%s %s)", lat, lng);
+        String userPoint = String.format("POINT(%s %s)", lng, lat);
         int radius = 1000;
         int limit = 10;
 
@@ -31,8 +31,8 @@ public class NearbyStationService {
                             (String) row[3],
                             combineAddress((String) row[4], (String) row[5]),
                             ((Number) row[8]).doubleValue(),
-                            (Double) row[6],
-                            (Double) row[7]
+                            (Double) row[7],
+                            (Double) row[6]
                     );
                 })
                 .collect(Collectors.toList()); // toList()로 변경


### PR DESCRIPTION
close #22 

### 🛠️ 해결방법
- MySQL에서 `POINT`타입을 사용할 때에는 반드시 경도, 위도 순으로 사용
- `POINT`타입에서 값을 꺼낼 땐 경도: `ST_X(변수명)`, 위도: `ST_Y(변수명)`로 사용