### PR TITLE
feat: 현재 위치 및 주변 대여소 반환, 위도/경도 문제 최종 해결

### DIFF
--- a/backend/src/main/java/com/zeun/ddamap/route/controller/NearbyStationController.java
+++ b/backend/src/main/java/com/zeun/ddamap/route/controller/NearbyStationController.java
@@ -16,7 +16,7 @@ public class NearbyStationController {
     private final NearbyStationService nearbyStationService;
 
     @GetMapping("/nearby")
-    public List<NearbyStationDTO> findNearbyStations(@RequestParam BigDecimal lng, @RequestParam BigDecimal lat) {
+    public List<NearbyStationDTO> findNearbyStations(@RequestParam BigDecimal lat, @RequestParam BigDecimal lng) {
 
         return nearbyStationService.findNearbyStationsWithDistance(lat, lng);
     }

--- a/backend/src/main/java/com/zeun/ddamap/route/repository/NearbyStationRepository.java
+++ b/backend/src/main/java/com/zeun/ddamap/route/repository/NearbyStationRepository.java
@@ -5,24 +5,24 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface NearbyStationRepository extends JpaRepository<Station, String> {
 
+    // id와 거리만 반환
     @Query(
-            value = "SELECT S.STN_ID, S.STN_NO, S.GROUP_ID, S.STN_NAME, S.STN_ADDR1, S.STN_ADDR2, " +
-                    "ST_Y(S.LOCATION) LATITUDE, ST_X(S.LOCATION) LONGITUDE, " +
-                    "ST_Distance_Sphere(S.LOCATION, ST_PointFromText(:userPoint, 4326)) AS DISTANCE " +
-                    "FROM   STATION S " +
-                    "WHERE  ST_Distance_Sphere(S.LOCATION, ST_PointFromText(:userPoint, 4326)) <= :radius " +
-                    "ORDER BY DISTANCE ASC " +
+            value = "SELECT     s.stn_id, ST_Distance_Sphere(s.location, ST_SRID(POINT(:longitude, :latitude), 4326)) as distance " +
+                    "FROM       station s " +
+                    "WHERE      ST_Distance_Sphere(s.location, ST_SRID(POINT(:longitude, :latitude), 4326)) <= :radius " +
+                    "ORDER BY distance ASC " +
                     "LIMIT :limit",
             nativeQuery = true
     )
-
-    List<Object[]> findNearbyStationsWithDistance(
-            @Param("userPoint") String userPoint,
-            @Param("radius") int radius,
-            @Param("limit") int limit
+    List<Object[]> findNearbyStationIds(
+                                         @Param("latitude") BigDecimal latitude,
+                                         @Param("longitude") BigDecimal longitude,
+                                         @Param("radius") int radius,
+                                         @Param("limit") int limit
     );
 }

--- a/backend/src/main/java/com/zeun/ddamap/route/service/NearbyStationService.java
+++ b/backend/src/main/java/com/zeun/ddamap/route/service/NearbyStationService.java
@@ -2,12 +2,16 @@ package com.zeun.ddamap.route.service;
 
 import com.zeun.ddamap.route.repository.NearbyStationRepository;
 import com.zeun.ddamap.route.dto.NearbyStationDTO;
+import com.zeun.ddamap.station.domain.Station;
+import com.zeun.ddamap.station.repository.StationRepository;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -15,27 +19,43 @@ import java.util.stream.Collectors;
 public class NearbyStationService {
 
     private final NearbyStationRepository nearbyStationRepository;
+    private final StationRepository stationRepository; // Station의 상세 정보를 가져오기 위해 주입!
 
-    public List<NearbyStationDTO> findNearbyStationsWithDistance(BigDecimal lng, BigDecimal lat) {
+    public List<NearbyStationDTO> findNearbyStationsWithDistance(BigDecimal latitude, BigDecimal longitude) {
 
-        String userPoint = String.format("POINT(%s %s)", lng, lat);
         int radius = 1000;
         int limit = 10;
 
-        List<Object[]> results = nearbyStationRepository.findNearbyStationsWithDistance(userPoint, radius, limit);
+        List<Object[]> idAndDistanceList = nearbyStationRepository.findNearbyStationIds(latitude, longitude, radius, limit);
 
-        return results.stream()
-                .map(row -> {
+        List<String> stationIds = idAndDistanceList.stream()
+                .map(row -> (String) row[0])
+                .collect(Collectors.toList());
+
+        Map<String, Double> distanceMap = idAndDistanceList.stream()
+                .collect(Collectors.toMap(
+                        row -> (String) row[0],
+                        row -> ((Number) row[1]).doubleValue()
+                ));
+
+        List<Station> stations = stationRepository.findAllById(stationIds);
+
+        return stations.stream()
+                .map(station -> {
+                    Point location = station.getLocation();
+                    Double distance = distanceMap.get(station.getStnId());
+
                     return new NearbyStationDTO(
-                            (String) row[0],
-                            (String) row[3],
-                            combineAddress((String) row[4], (String) row[5]),
-                            ((Number) row[8]).doubleValue(),
-                            (Double) row[7],
-                            (Double) row[6]
+                            station.getStnId(),
+                            station.getStnName(),
+                            combineAddress(station.getStnAddr1(), station.getStnAddr2()),
+                            distance,
+                            BigDecimal.valueOf(location.getY()).doubleValue(),
+                            BigDecimal.valueOf(location.getX()).doubleValue()
                     );
                 })
-                .collect(Collectors.toList()); // toList()로 변경
+                .sorted(Comparator.comparing(NearbyStationDTO::distance))
+                .collect(Collectors.toList());
     }
 
     private String combineAddress(String addr1, String addr2) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ function App() {
 
   const naverMapsClientId = import.meta.env.VITE_NAVER_MAP_CLIENT_ID;
 
+/*
 
   useEffect(() => {    
     const fetchStations = async () => {
@@ -19,6 +20,7 @@ function App() {
     };
     fetchStations();
   }, []);
+*/
 
   return (
     <NavermapsProvider ncpKeyId={ naverMapsClientId }>

--- a/frontend/src/api/geolocationApi.js
+++ b/frontend/src/api/geolocationApi.js
@@ -1,0 +1,21 @@
+
+export const getUserLocation = () => {
+    return new Promise((resolve, reject) => {
+        if (!navigator.geolocation) {
+            reject(new Error("Geolocation is not supported by this browser."));
+            return;
+        }
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                resolve({
+                    lat: position.coords.latitude,
+                    lng: position.coords.longitude,
+                });
+            },
+            (error) => {
+                reject(error);
+            }
+        );
+    });
+};

--- a/frontend/src/api/stationApi.js
+++ b/frontend/src/api/stationApi.js
@@ -11,3 +11,13 @@ export const getAllStations = async() => {
         throw error;
     }
 }
+
+export const getNearbyStations = async(lat, lng) => {
+    try {
+        const response = await axios.get(`${API_BASE_URL}/api/v1/stations/nearby?lat=${lat}&lng=${lng}`);
+        return response.data;
+    } catch (error) {
+        console.error("Error fetching nearby stations: ", error);
+        throw error;
+    }
+}

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -1,15 +1,64 @@
-import { Container as MapDiv, NaverMap, Marker } from "react-naver-maps"
+import { Container as MapDiv, NaverMap, Marker, useNavermaps } from "react-naver-maps";
+import { useState, useEffect } from "react";
+import { getNearbyStations } from "../api/stationApi.js";
+import { getUserLocation } from "../api/geolocationApi.js";
 
 export default function MapContainer() {
 
+    const navermaps = useNavermaps();
+    const [userLocation, setUserLocation] = useState(null);
+    const [nearbyStations, setNearbyStations] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchUserLocation = async () => {
+            try {
+                const locationData = await getUserLocation();
+                setUserLocation(locationData);
+            } catch (error) {
+                console.error("위치 정보를 불러오는 중에 오류가 발생했습니다.", error);
+                setUserLocation({ lat: 37.5139, lng: 127.1022 });
+            }
+        };
+        fetchUserLocation();
+    }, []);
+
+    useEffect(() => {
+        if (!userLocation) {
+            return;
+        }
+        const fetchNearbyStations = async () => {
+            setIsLoading(true);
+            try {
+                const data = await getNearbyStations(userLocation.lat, userLocation.lng);
+                setNearbyStations(data);
+                console.log(data);
+                console.log(nearbyStations);
+            } catch (error) {
+                console.error("근처 대여소 정보를 불러오는 중에 오류가 발생했습니다.", error);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchNearbyStations();
+    }, [userLocation]);
+
+    if (isLoading || !userLocation) {
+        return <div>지도 로딩 중...</div>;
+    }
+
     return (
-        <MapDiv 
-            style={{ width: '100vw', height: '600vh' }}>
-                <NaverMap
-                    defaultCenter={{ lat: 37.5139, lng: 127.1022 }}
-                    defaultZoom={ 15 }>
-                    <Marker defaultPosition={{ lat: 37.5139, lng: 127.1022 }} />
-                </NaverMap>
+        <MapDiv style={{ width: '80vw', height: '80vh' }}>
+            <NaverMap center={userLocation} defaultZoom={15}>
+                <Marker position={userLocation} />
+
+                {nearbyStations.map(station => (
+                    <Marker
+                        key={station.stnId}
+                        position={new navermaps.LatLng(station.latitude, station.longitude)}
+                    />
+                ))}
+            </NaverMap>
         </MapDiv>
-    )
+    );
 }


### PR DESCRIPTION
## 관련된 이슈 🔗
Closes #21 


## 작업 내용 📝
- frontend
  - `navigator.geolocation`을 사용하여 frontend에서 현재 위치 불러옴
  - 현재 위치를 중심으로 한 지도 반환
  - `/api/v1/stations/nearby?lat=${lat}&lng=${lng}` 엔드포인트 요청을 통해 현재 위치 기준 주변 대여소 목록 반환
  - 반환받은 대여소 목록 `marker`로 표시

- backend
  - 필드, 변수, 파라미터 순서를 `latitude`, `longitude`(`lat`, `lng`)로 통일
  - native query 사용 시 ST_X, ST_Y, POINT 값들 간의 알 수 없는 경도, 위도 불일치 문제로 `id`,`distance`를 제외한 나머지 정보는 JPA로 조회 및 반환

## 스크린샷 📸
![image](https://github.com/user-attachments/assets/c948f8fa-c163-47be-8a88-1fce82821593)

## 남길 말