### PR TITLE
feat(fe): 대여소 세부 정보 표시 및 css 적용

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,24 @@
+.App {
+    width: 100vw;
+    min-height: 100vh;
+    background-color: #f0f2f5;
+    display: flex;
+    justify-content: center;
+}
+
+.App-container {
+    width: 100%;
+    height: 100vh;
+    background-color: white;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    max-width: 650px;
+    display: flex;
+    flex-direction: column;
+}
+
+@media (max-width: 1024px) {
+    .App-container {
+        max-width: 100%;
+        box-shadow: none;
+    }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,35 +1,21 @@
-import React, { useEffect } from 'react';
-import { getAllStations } from './api/stationApi';
 import MapContainer from './components/MapContainer';
 import { NavermapsProvider } from 'react-naver-maps';
+import './App.css';
 
 function App() {
+    const naverMapsClientId = import.meta.env.VITE_NAVER_MAP_CLIENT_ID;
 
-  const naverMapsClientId = import.meta.env.VITE_NAVER_MAP_CLIENT_ID;
 
-/*
-
-  useEffect(() => {    
-    const fetchStations = async () => {
-      try {
-        const stations = await getAllStations();
-        console.log("백엔드에서 받아온 대여소 목록: ", stations);
-      } catch (error) {
-        console.error("API 호출 실패: ", error);
-      }
-    };
-    fetchStations();
-  }, []);
-*/
-
-  return (
-    <NavermapsProvider ncpKeyId={ naverMapsClientId }>
-      <div style={{ width: '100vw', height: '100vh' }} >
-        <h1>따맵</h1>
-        <MapContainer />
-      </div>
-    </NavermapsProvider>
-  )
+    return (
+        <NavermapsProvider ncpKeyId={naverMapsClientId}>
+            <div className="App">
+                <div className="App-container">
+                    <h1>따맵</h1>
+                    <MapContainer/>
+                </div>
+            </div>
+        </NavermapsProvider>
+    );
 }
 
 export default App;

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -58,22 +58,22 @@ export default function MapContainer() {
     }
 
     return (
-        <div style={{ position: 'relative'}}>
-            <MapDiv style={{ width: '80vw', height: '80vh' }}>
-                <NaverMap center={userLocation} defaultZoom={15}>
-                    <Marker position={userLocation} />
+        <div style={{ position: 'relative', width: '100%', height: 'calc(100% - 50px)' }}> {/* h1 높이만큼 빼주기 */}
+            <MapDiv style={{ width: '100%', height: '100%' }}>
+                    <NaverMap center={userLocation} defaultZoom={15}>
+                        <Marker position={userLocation} />
 
-                    {nearbyStations.map(station => (
-                        <Marker onClick={() => { handleMarkerOnclick(station) }}
-                            key={station.stnId}
-                            position={new navermaps.LatLng(station.latitude, station.longitude)}
-                        />
-                    ))}
-                </NaverMap>
-            </MapDiv>
-            {selectedStation && (
-                <StationDetail station={selectedStation} onClose={handlePanelClose}/>
-            )}
+                        {nearbyStations.map(station => (
+                            <Marker onClick={() => { handleMarkerOnclick(station) }}
+                                key={station.stnId}
+                                position={new navermaps.LatLng(station.latitude, station.longitude)}
+                            />
+                        ))}
+                    </NaverMap>
+                </MapDiv>
+                {selectedStation && (
+                    <StationDetail station={selectedStation} onClose={handlePanelClose}/>
+                )}
         </div>
     );
 }

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -2,12 +2,14 @@ import { Container as MapDiv, NaverMap, Marker, useNavermaps } from "react-naver
 import { useState, useEffect } from "react";
 import { getNearbyStations } from "../api/stationApi.js";
 import { getUserLocation } from "../api/geolocationApi.js";
+import StationDetail from "./StationDetail.jsx";
 
 export default function MapContainer() {
 
     const navermaps = useNavermaps();
     const [userLocation, setUserLocation] = useState(null);
     const [nearbyStations, setNearbyStations] = useState([]);
+    const [selectedStation, setSelectedStation] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
@@ -43,22 +45,35 @@ export default function MapContainer() {
         fetchNearbyStations();
     }, [userLocation]);
 
+    const handleMarkerOnclick = (station) => {
+        setSelectedStation(station);
+    }
+
+    const handlePanelClose = () => {
+        setSelectedStation(null);
+    };
+
     if (isLoading || !userLocation) {
         return <div>지도 로딩 중...</div>;
     }
 
     return (
-        <MapDiv style={{ width: '80vw', height: '80vh' }}>
-            <NaverMap center={userLocation} defaultZoom={15}>
-                <Marker position={userLocation} />
+        <div style={{ position: 'relative'}}>
+            <MapDiv style={{ width: '80vw', height: '80vh' }}>
+                <NaverMap center={userLocation} defaultZoom={15}>
+                    <Marker position={userLocation} />
 
-                {nearbyStations.map(station => (
-                    <Marker
-                        key={station.stnId}
-                        position={new navermaps.LatLng(station.latitude, station.longitude)}
-                    />
-                ))}
-            </NaverMap>
-        </MapDiv>
+                    {nearbyStations.map(station => (
+                        <Marker onClick={() => { handleMarkerOnclick(station) }}
+                            key={station.stnId}
+                            position={new navermaps.LatLng(station.latitude, station.longitude)}
+                        />
+                    ))}
+                </NaverMap>
+            </MapDiv>
+            {selectedStation && (
+                <StationDetail station={selectedStation} onClose={handlePanelClose}/>
+            )}
+        </div>
     );
 }

--- a/frontend/src/components/StationDetail.jsx
+++ b/frontend/src/components/StationDetail.jsx
@@ -1,0 +1,26 @@
+export default function StationDetail({ station, onClose}) {
+
+    const panelStyle = {
+        position: 'absolute',
+        bottom: '35px',
+        left: '26px',
+        right: '26px',
+        height: '20vh',
+        backgroundColor: 'white',
+        borderRadius: '12px',
+        boxShadow: '0 -2px 10px rgba(0, 0, 0, 0.15)',
+        padding: '20px',
+        boxSizing: 'border-box',
+        zIndex: 100,
+        transition: 'transform 0.3s ease-in-out',
+        transform: 'translateY(0)',
+    };
+
+    return (
+        <div style={panelStyle}>
+            <button onClick={onClose}>X</button>
+            <h2>{station.stnName}</h2>
+            <p>{station.address}</p><p>내 위치에서 {parseInt(station.distance)}m</p>
+        </div>
+    )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,5 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: sans-serif;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import './index.css';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>


### PR DESCRIPTION
## 관련된 이슈 🔗
#24  


## 작업 내용 📝
- 현재 위치 기준으로 보여진 근처 대여소 마커를 클릭하면 상세정보 panel을 띄워줌
- 선택된 대여소 상태관리를 통해 panel을 보여줌
- 반응형 디자인을 적용하여 웹, 스마트폰, 태블릿에 따라 적절한 디자인 사용

## 스크린샷 📸
![image](https://github.com/user-attachments/assets/42d570e1-218c-4a01-aa8d-ed6b8458e8c0)

## 남길 말