### PR TITLE
feat(be): 대여소 실시간 정보 api 호출 추가

### DIFF
--- a/backend/src/main/java/com/zeun/ddamap/station/controller/StationController.java
+++ b/backend/src/main/java/com/zeun/ddamap/station/controller/StationController.java
@@ -1,11 +1,13 @@
 package com.zeun.ddamap.station.controller;
 
 import com.zeun.ddamap.station.dto.StationResponseDTO;
+import com.zeun.ddamap.station.dto.externalRealtime.BikeStatusRowDTO;
+import com.zeun.ddamap.station.dto.externalRealtime.RentBikeStatusDTO;
+import com.zeun.ddamap.station.service.RealTimeStationService;
 import com.zeun.ddamap.station.service.StationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 @RestController
@@ -14,11 +16,18 @@ import java.util.List;
 public class StationController {
 
     private final StationService stationService;
+    private final RealTimeStationService realTimeStationService;
 
-    @GetMapping
+/*    @GetMapping
     public List<StationResponseDTO> getAllStations() {
 
         return stationService.getAllStations();
+    }*/
+
+    @GetMapping
+    public List<BikeStatusRowDTO> getRealtimeStations() {
+
+        return realTimeStationService.fetchAllRealtimeStations();
     }
 
 }

--- a/backend/src/main/java/com/zeun/ddamap/station/dto/externalRealtime/BikeStatusApiResponseDTO.java
+++ b/backend/src/main/java/com/zeun/ddamap/station/dto/externalRealtime/BikeStatusApiResponseDTO.java
@@ -1,0 +1,7 @@
+package com.zeun.ddamap.station.dto.externalRealtime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record BikeStatusApiResponseDTO(
+        @JsonProperty("rentBikeStatus") RentBikeStatusDTO rentBikeStatus
+) {}

--- a/backend/src/main/java/com/zeun/ddamap/station/dto/externalRealtime/BikeStatusRowDTO.java
+++ b/backend/src/main/java/com/zeun/ddamap/station/dto/externalRealtime/BikeStatusRowDTO.java
@@ -1,0 +1,14 @@
+package com.zeun.ddamap.station.dto.externalRealtime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record BikeStatusRowDTO(
+
+        @JsonProperty("rackTotCnt") String rackTotalCount,
+        @JsonProperty("stationName") String stationName,
+        @JsonProperty("parkingBikeTotCnt") String parkingBikeTotalCount,
+        @JsonProperty("shared") String shared,
+        @JsonProperty("stationLatitude") String stationLatitude,
+        @JsonProperty("stationLongitude") String stationLongitude,
+        @JsonProperty("stationId") String stationId
+) {}

--- a/backend/src/main/java/com/zeun/ddamap/station/dto/externalRealtime/RentBikeStatusDTO.java
+++ b/backend/src/main/java/com/zeun/ddamap/station/dto/externalRealtime/RentBikeStatusDTO.java
@@ -1,0 +1,10 @@
+package com.zeun.ddamap.station.dto.externalRealtime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record RentBikeStatusDTO(
+        @JsonProperty("list_total_count") int listTotalCount,
+        @JsonProperty("row") List<BikeStatusRowDTO> row
+) {}

--- a/backend/src/main/java/com/zeun/ddamap/station/service/RealTimeStationService.java
+++ b/backend/src/main/java/com/zeun/ddamap/station/service/RealTimeStationService.java
@@ -1,0 +1,66 @@
+package com.zeun.ddamap.station.service;
+
+import com.zeun.ddamap.station.dto.externalRealtime.BikeStatusApiResponseDTO;
+import com.zeun.ddamap.station.dto.externalRealtime.BikeStatusRowDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class RealTimeStationService {
+
+    private final WebClient webClient;
+    private final String apiKey;
+
+    public RealTimeStationService(WebClient webClient, @Value("${api.seoul.key}") String apiKey) {
+        this.webClient = webClient;
+        this.apiKey = apiKey;
+    }
+
+    public List<BikeStatusRowDTO> fetchAllRealtimeStations() {
+        List<BikeStatusRowDTO> allStations = new ArrayList<>();
+        int start = 1;
+        int batchSize = 1000;
+
+        while (true) {
+            int end = start + batchSize - 1;
+            System.out.println("Fetching stations from " + start + " to " + end);
+
+            BikeStatusApiResponseDTO response = callRealtimeBikeApi(start, end);
+
+            if (response == null || response.rentBikeStatus() == null || response.rentBikeStatus().row() == null || response.rentBikeStatus().row().isEmpty()) {
+                System.out.println("No more data to fetch. Exiting loop.");
+                break;
+            }
+
+            List<BikeStatusRowDTO> currentPageStations = response.rentBikeStatus().row();
+            allStations.addAll(currentPageStations);
+            System.out.println("Fetched " + currentPageStations.size() + " stations. Total: " + allStations.size());
+
+            if (currentPageStations.size() < batchSize) {
+                System.out.println("Last page reached. Exiting loop.");
+                break;
+            }
+
+            start += batchSize;
+        }
+
+        return allStations;
+    }
+
+    private BikeStatusApiResponseDTO callRealtimeBikeApi(int startIndex, int endIndex) {
+        String serviceName = "bikeList";
+        String path = String.format("/%s/json/%s/%d/%d", apiKey, serviceName, startIndex, endIndex);
+
+        Mono<BikeStatusApiResponseDTO> mono = webClient.get()
+                .uri(path)
+                .retrieve()
+                .bodyToMono(BikeStatusApiResponseDTO.class);
+
+        return mono.block();
+    }
+}


### PR DESCRIPTION
## 관련된 이슈 🔗
Closes #30 


## 작업 내용 📝
- 공공데이터의 실시간 대여소 정보 API 호출 로직을 추가하였습니다.
- 기존 대여소 정보는 삭제하지 않았습니다.

## 스크린샷 📸

## 남길 말
- 여러가지 대여소 정보 API가 존재하는데 가지고 있는 데이터가 모두 상이하여 검토 필요